### PR TITLE
from django.http import HttpResponseNotFound for line 19

### DIFF
--- a/photonix/photos/views.py
+++ b/photonix/photos/views.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseNotFound
 
 from photonix.photos.utils.thumbnails import get_thumbnail
 


### PR DESCRIPTION
Fix an undefined name...

[flake8](http://flake8.pycqa.org) testing of https://github.com/damianmoore/photonix on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./photonix/photos/views.py:19:16: F821 undefined name 'HttpResponseNotFound'
        return HttpResponseNotFound('No photo thumbnail with these parameters')
               ^
1     F821 undefined name 'HttpResponseNotFound'
1
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree