### PR TITLE
Cope with odd apertures in EXIF, and large files/videos in source data

### DIFF
--- a/photonix/photos/utils/db.py
+++ b/photonix/photos/utils/db.py
@@ -72,10 +72,21 @@ def record_photo(path):
 
     if not photo:
         # Save Photo
+
+        aperture = None
+        aperturestr = metadata.get('Aperture')
+        if aperturestr:
+            try:
+                aperture = Decimal(aperturestr)
+                if aperture.is_infinite():
+                    aperture = None
+            except:
+                pass
+
         photo = Photo(
             taken_at=date_taken,
             taken_by=metadata.get('Artist') or None,
-            aperture=metadata.get('Aperture') and Decimal(metadata.get('Aperture')) or None,
+            aperture=aperture,
             exposure=metadata.get('Exposure Time') or None,
             iso_speed=metadata.get('ISO') and int(metadata.get('ISO')) or None,
             focal_length=metadata.get('Focal Length') and metadata.get('Focal Length').split(' ', 1)[0] or None,

--- a/photonix/photos/utils/organise.py
+++ b/photonix/photos/utils/organise.py
@@ -82,6 +82,13 @@ def determine_same_file(origpath, destpath, fhc=None):
     return False
 
 
+def blacklisted_type(file):
+    if file[-4:].lower() == '.mov' or file[-4:].lower() == '.mp4' or file[-4:].lower() == '.mkv':
+        return True
+    if file == '.DS_Store':
+        return True
+    return False
+
 def import_photos_from_dir(orig, move=False):
     imported = 0
     were_duplicates = 0
@@ -91,11 +98,17 @@ def import_photos_from_dir(orig, move=False):
         for fn in sorted(f):
             filepath = os.path.join(r, fn)
             dest = determine_destination(filepath)
-            if not dest:
+            if blacklisted_type(fn):
+                # Blacklisted type
+                were_bad += 1
+            elif not dest:
                 # No filters match this file type
                 pass
             elif os.path.getsize(filepath) < 102400:
                 print('FILE VERY SMALL (<100k - PROBABLY THUMBNAIL), NOT IMPORTING {}'.format(filepath))
+                were_bad += 1
+            elif os.path.getsize(filepath) > 1073741824:
+                print('FILE VERY LARGE (>1G - PROBABLY VIDEO), NOT IMPORTING {}'.format(filepath))
                 were_bad += 1
             else:
                 t = get_datetime(filepath)
@@ -149,8 +162,14 @@ def import_photos_in_place(orig):
     for r, d, f in os.walk(orig):
         for fn in sorted(f):
             filepath = os.path.join(r, fn)
-            if os.path.getsize(filepath) < 102400:
+            if blacklisted_type(fn):
+                # Blacklisted type
+                were_bad += 1
+            elif os.path.getsize(filepath) < 102400:
                 print('FILE VERY SMALL (<100k - PROBABLY THUMBNAIL), NOT IMPORTING {}'.format(filepath))
+                were_bad += 1
+            elif os.path.getsize(filepath) > 1073741824:
+                print('FILE VERY LARGE (>1G - PROBABLY VIDEO), NOT IMPORTING {}'.format(filepath))
                 were_bad += 1
             else:
                 modified = record_photo(filepath)


### PR DESCRIPTION
Trying to run photonix against my photo-library quickly revealed two issues:

1. Some photos contain odd aperture values (`undef`, `Infinity`, `Inf`), supposedly as a result of using lenses without read out (e.g. purely mechanical lenses). The "infinity" value of the Decimal type is not supported by Django, which caused Django to throw.
2. The database scheme uses a 32-bit signed integer for size, which fails hard when bumping into 4GB video clips that live together with my photos. This size error also caused Django to throw.

The first is fixed by setting apertures that do not parse, as well as aperture that are infinite, to None.

Furthermore, a rule avoiding 1GB files, as well as a type blacklist for the most obvious contenders was added, allowing photonix to handle the situation a bit more gracefully.

With these changes, photonix is now slowly crunching my library. With a lot of emphasis on "slowly".