### PR TITLE
Add better logging for failed downloads

### DIFF
--- a/photonix/classifiers/base_model.py
+++ b/photonix/classifiers/base_model.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 import tempfile
 from pathlib import Path
+import logging
 
 import requests
 
@@ -14,6 +15,7 @@ from redis_lock import Lock
 
 graph_cache = {}
 
+logger = logging.getLogger(__name__)
 
 class BaseModel:
     def __init__(self, model_dir=None):
@@ -71,6 +73,8 @@ class BaseModel:
 
                     if request.status_code != 200:
                         error = True
+                        logger.error(f"Failed to fetch model for {location}: "
+                                     f"Got {request.status_code}")
                         continue
 
                     # Download file to temporary location
@@ -96,6 +100,8 @@ class BaseModel:
                         shutil.move(f.name, final_path)
                     else:
                         error = True
+                        logger.error(f"File downloaded from {location} is "
+                                     "corrupt as indicated by bad hash")
                         # TODO: Delete badly downloaded file
 
             # Write version file

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     zip_safe=False,
     classifiers=[
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
     install_requires=install_requires, )


### PR DESCRIPTION
This provides a better error message for https://github.com/damianmoore/photonix/issues/87:

```
E0705 03:16:28.388792 140356725630592 base_model.py:76] Failed to fetch model for https://epixstudios.co.uk/filer/canonical/1545247275/11/: Got 404
E0705 03:16:28.825588 140356725630592 base_model.py:76] Failed to fetch model for https://epixstudios.co.uk/filer/canonical/1545247247/10/: Got 404
```