### PR TITLE
Update libpq-dev and nginx-light

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,10 @@ RUN apt-get update && \
         gunicorn=19.6.0-10+deb9u1 \
         libimage-exiftool-perl=10.40-1 \
         libjpeg-dev=1:1.5.1-2 \
-        libpq-dev=9.6.13-0+deb9u1 \
+        libpq-dev=9.6.15-0+deb9u1 \
         libtiff5-dev=4.0.8-2+deb9u4 \
         netcat=1.10-41 \
-        nginx-light=1.10.3-1+deb9u2 \
+        nginx-light=1.10.3-1+deb9u3 \
         supervisor=3.3.1-1+deb9u1 \
         && \
         apt-get clean && \


### PR DESCRIPTION
Updates libpq-dev and nginx-light to versions which are still available in the package sources.

The Docker image can't be built due to out of date packages which are not available anymore. Therefore `docker-compose.dev build` doesn't work either.

