### PR TITLE
Added CR3 Support

### DIFF
--- a/photonix/photos/utils/metadata.py
+++ b/photonix/photos/utils/metadata.py
@@ -83,3 +83,11 @@ def get_dimensions(path):
     if metadata.data.get('Image Width') and metadata.data.get('Image Height'):
         return (int(metadata.data['Image Width']), int(metadata.data['Image Height']))
     return (None, None)
+
+def get_mimetype(path):
+    # Done
+    """Pulls the MIME Type from the given path"""
+    metadata = PhotoMetadata(path)
+    if metadata.data.get('MIME Type'):
+        return metadata.data.get('MIME Type')
+    return None

--- a/photonix/photos/utils/raw.py
+++ b/photonix/photos/utils/raw.py
@@ -80,6 +80,19 @@ def __get_generated_image(temp_dir, basename):
         if fn != basename:
             return Path(temp_dir) / fn
 
+def __get_exiftool_image(temp_dir, basename):
+    """
+    Exiftool outputs two files when copying the tags over, we
+    want the file that ends in .jpg and not .jpg_original, but
+    to keep the filesystem tidy we need to get the path.
+    """
+    exiftool_files = {}
+    for fn in os.listdir(temp_dir):
+        if fn.endswith('.jpg_original'):
+            exiftool_files['original']: Path(temp_dir) / fn
+        if fn.endswith('.jpg'):
+            exiftool_files['output']: Path(temp_dir) / fn
+    return exiftool_files
 
 def __has_acceptable_dimensions(original_image_path, new_image_path, accept_empty_original_dimensions=False):
     original_image_dimensions = get_dimensions(original_image_path)
@@ -140,9 +153,29 @@ def generate_jpeg(path):
     valid_image = False
     process_params = None
 
-    # First try to extract the JPEG that might be inside the raw file
-    subprocess.run(['dcraw', '-e', temp_input_path])
-    temp_output_path = __get_generated_image(temp_dir, basename)
+    # Handle Canon's CR3 format since their thumbnails are proprietary.
+    mimetype = get_mimetype(temp_input_path)
+    if mimetype == 'image/x-canon-cr3':
+        subprocess.Popen([
+            'exiftool', '-b', '-JpgFromRaw', '-w', 'jpg', '-ext', 'CR3',
+            temp_input_path, '-execute', '-tagsfromfile', temp_input_path,
+            '-ext', 'jpg', Path(temp_dir)],
+            stdout=subprocess.PIPE,
+            stdin=subprocess.PIPE,
+            stderr=subprocess.PIPE).communicate()
+        exiftool_output = __get_exiftool_image(temp_dir, basename)
+        # Clean up the original file without tags.
+        if 'original' in exiftool_output:
+            os.remove(exiftool_output['original'])
+        # Set the input file.
+        if 'output' in exiftool_output:
+            temp_output_path = exiftool_output['output']
+        else:
+            temp_output_path = None
+    else:
+        # First try to extract the JPEG that might be inside the raw file
+        subprocess.run(['dcraw', '-e', temp_input_path])
+        temp_output_path = __get_generated_image(temp_dir, basename)
 
     # Check the JPEGs dimensions are close enough to the raw's dimensions
     if temp_output_path:


### PR DESCRIPTION
dcraw cannot extract the thumbnail of CR3 images due to some proprietary limitations put in place by Canon. It's unclear if they will ever open that specification up so exiftool will have to be used to generate a thumbnail.

Added in get_mimetype() to metadata.py
Added in __get_exiftool_image() to raw.py
Modified generate_jpeg() to handle CR3 files by getting the mimetype first and then running exiftool if it's identified as one.

Fixes #202 